### PR TITLE
Broadcast txs to all orderers

### DIFF
--- a/pkg/fab/txn/txn.go
+++ b/pkg/fab/txn/txn.go
@@ -183,8 +183,7 @@ func BroadcastPayload(reqCtx reqContext.Context, payload *common.Payload, ordere
 	return broadcastEnvelope(reqCtx, envelope, orderers)
 }
 
-// broadcastEnvelope will send the given envelope to all orderers
-// until all are exhausted
+// broadcastEnvelope will send the given envelope to the all orderers
 func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, orderers []fab.Orderer) (*fab.TransactionResponse, error) {
 	// Check if orderers are defined
 	if len(orderers) == 0 {
@@ -201,7 +200,7 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 
 	broadcastResponses := make(chan TxResponseWithErrMsg, orderersN)
 
-	// broadcast to all orderers
+	// broadcast to the all orderers
 	for _, orderer := range orderers {
 		go func() {
 			resp, err := sendBroadcast(reqCtx, envelope, orderer, ctxClient)
@@ -213,7 +212,7 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 	}
 
 	// read responses
-	// if no errors in first response, return successful response
+	// if no errors in the first response, return successful response
 	// if error returned, wait for the next response
 	isAllOrderersFail := orderersResponsesChecker()
 	for i := 0; i < orderersN; i++ {

--- a/pkg/fab/txn/txn.go
+++ b/pkg/fab/txn/txn.go
@@ -202,13 +202,13 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 
 	// broadcast to the all orderers
 	for _, orderer := range orderers {
-		go func() {
+		go func(orderer fab.Orderer) {
 			resp, err := sendBroadcast(reqCtx, envelope, orderer, ctxClient)
 			broadcastResponses <- TxResponseWithErrMsg{
 				TxResponse: resp,
 				Error:      err,
 			}
-		}()
+		}(orderer)
 	}
 
 	// read responses

--- a/pkg/fab/txn/txn.go
+++ b/pkg/fab/txn/txn.go
@@ -197,7 +197,9 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 		return nil, errors.New("failed get client context from reqContext for SendTransaction")
 	}
 
-	broadcastResponses := make(chan TxResponseWithErrMsg, len(orderers))
+	orderersN := len(orderers)
+
+	broadcastResponses := make(chan TxResponseWithErrMsg, orderersN)
 
 	// broadcast to all orderers
 	for _, orderer := range orderers {
@@ -209,8 +211,6 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 			}
 		}()
 	}
-
-	orderersN := len(orderers)
 
 	// read responses
 	// if no errors in first response, return successful response

--- a/pkg/fab/txn/txn.go
+++ b/pkg/fab/txn/txn.go
@@ -34,6 +34,23 @@ const (
 	Upgrade
 )
 
+type TxResponseWithErrMsg struct {
+	TxResponse *fab.TransactionResponse
+	Error      error
+}
+
+func orderersResponsesChecker() func(resp *TxResponseWithErrMsg, orderersNumber int) bool {
+	var numberOfCalls int
+	return func(resp *TxResponseWithErrMsg, orderersNumber int) bool {
+		numberOfCalls += 1
+		return resp.Error != nil && numberOfCalls == orderersNumber
+	}
+}
+
+func successfulOrdererResponse(resp *TxResponseWithErrMsg) bool {
+	return resp.Error == nil
+}
+
 // New create a transaction with proposal response, following the endorsement policy.
 func New(request fab.TransactionRequest) (*fab.Transaction, error) {
 	if len(request.ProposalResponses) == 0 {
@@ -161,7 +178,7 @@ func BroadcastPayload(reqCtx reqContext.Context, payload *common.Payload, ordere
 	return broadcastEnvelope(reqCtx, envelope, orderers)
 }
 
-// broadcastEnvelope will send the given envelope to some orderer, picking random endpoints
+// broadcastEnvelope will send the given envelope to all orderers
 // until all are exhausted
 func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, orderers []fab.Orderer) (*fab.TransactionResponse, error) {
 	// Check if orderers are defined
@@ -169,27 +186,38 @@ func broadcastEnvelope(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, 
 		return nil, errors.New("orderers not set")
 	}
 
-	// Copy aside the ordering service endpoints
-	randOrderers := []fab.Orderer{}
-	randOrderers = append(randOrderers, orderers...)
-
 	// get a context client instance to create child contexts with timeout read from the config in sendBroadcast()
 	ctxClient, ok := context.RequestClientContext(reqCtx)
 	if !ok {
 		return nil, errors.New("failed get client context from reqContext for SendTransaction")
 	}
 
-	// Iterate them in a random order and try broadcasting 1 by 1
-	var errResp error
-	for _, i := range rand.Perm(len(randOrderers)) {
-		resp, err := sendBroadcast(reqCtx, envelope, randOrderers[i], ctxClient)
-		if err != nil {
-			errResp = err
-		} else {
-			return resp, nil
+	broadcastResponses := make(chan TxResponseWithErrMsg, len(orderers))
+
+	// broadcast to all orderers
+	for _, orderer := range orderers {
+		go func() {
+			resp, err := sendBroadcast(reqCtx, envelope, orderer, ctxClient)
+			broadcastResponses <- TxResponseWithErrMsg{
+				TxResponse: resp,
+				Error:      err,
+			}
+		}()
+	}
+
+	orderersN := len(orderers)
+
+	// read responses
+	// if no errors in first response, return successful response
+	// if error returned, wait for the next response
+	isAllOrderersFail := orderersResponsesChecker()
+	for i := 1; i <= orderersN; i++ {
+		resp := <-broadcastResponses
+		if isAllOrderersFail(&resp, orderersN) || successfulOrdererResponse(&resp) {
+			return resp.TxResponse, resp.Error
 		}
 	}
-	return nil, errResp
+	return nil, nil
 }
 
 func sendBroadcast(reqCtx reqContext.Context, envelope *fab.SignedEnvelope, orderer fab.Orderer, client ctxprovider.Client) (*fab.TransactionResponse, error) {


### PR DESCRIPTION
We need to broadcast transactions to the all SmartBFT orderers to avoid unnecessary delays associated with sending a transaction to a non-leader OSN.